### PR TITLE
Implement simple glossary output

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,10 +22,18 @@ lazy val tastyQueryCollector = (project in file("domainDocs4s-collector"))
   )
   .dependsOn(api)
   .dependsOn(testInput) //% "test->compile")
+  .dependsOn(examples)
 
 lazy val testInput = (project in file("domainDocs4s-test-input"))
   .settings(
     name              := "domainDocs4s-test-input",
+    semanticdbEnabled := true,
+  )
+  .dependsOn(api)
+
+lazy val examples = (project in file("domainDocs4s-examples"))
+  .settings(
+    name              := "domainDocs4s-examples",
     semanticdbEnabled := true,
   )
   .dependsOn(api)

--- a/domainDocs4s-collector/src/main/scala/domaindocs4s/collector/Main.scala
+++ b/domainDocs4s-collector/src/main/scala/domaindocs4s/collector/Main.scala
@@ -1,5 +1,6 @@
 package domaindocs4s.collector
 
+import domaindocs4s.output.Glossary
 import tastyquery.Contexts.Context
 import tastyquery.jdk.ClasspathLoaders
 
@@ -11,8 +12,10 @@ object Main {
 
     val cp        = ClasspathLoaders.read(
       List(
-        Path.of("/Users/krever/Projects/priv/domainDocs4s/domainDocs4s-api/target/scala-3.5.1/classes"),
-        Path.of("/Users/krever/Projects/priv/domainDocs4s/domainDocs4s-test-input/target/scala-3.5.1/classes"),
+        //        Path.of("/Users/krever/Projects/priv/domainDocs4s/domainDocs4s-api/target/scala-3.5.1/classes"),
+        //        Path.of("/Users/krever/Projects/priv/domainDocs4s/domainDocs4s-test-input/target/scala-3.5.1/classes"),
+        Path.of("/home/bartek/IdeaProjects/domainDocs4s/domainDocs4s-api/target/scala-3.5.1/classes"),
+        Path.of("/home/bartek/IdeaProjects/domainDocs4s/domainDocs4s-examples/target/scala-3.5.1/classes"),
       ),
     )
     given Context = Context.initialize(cp)
@@ -20,15 +23,20 @@ object Main {
     val collector = new TastyQueryCollector
 
     val docs = collector
-      .collectSymbols("domaindocs4stest")
-
-    docs.symbols
-      .foreach(println)
+      .collectSymbols("domaindocs4s.banking")
 
     def printTree(s: DocumentationTree, indent: Int = 0): Unit = {
-      println(s.symbol.symbol.toString.indent(indent))
-      s.children.foreach(printTree(_, indent + 1))
+      print(s.symbol.symbol.toString.indent(indent))
+      s.children.foreach(printTree(_, indent + 2))
     }
-    docs.asTree.foreach(printTree(_, 0))
+
+    println()
+    docs.asTree.foreach(printTree(_))
+
+    val mdGlossary = Glossary.build(docs).asMarkdown
+    val htmlGlossary = Glossary.build(docs).asHtml
+
+    Glossary.write(mdGlossary, "./glossary.md")
+    Glossary.write(htmlGlossary, "./glossary.html")
   }
 }

--- a/domainDocs4s-collector/src/main/scala/domaindocs4s/output/Glossary.scala
+++ b/domainDocs4s-collector/src/main/scala/domaindocs4s/output/Glossary.scala
@@ -1,20 +1,97 @@
 package domaindocs4s.output
 
-import domaindocs4s.collector.Documentation
+import domaindocs4s.collector.{Documentation, DocumentedSymbol}
+import domaindocs4s.output.Glossary.Entry
+
+import java.nio.file.Path
+import java.nio.file.Files
 
 case class Glossary(entries: List[Glossary.Entry]) {
 
-  def asMarkdown: String = ???
+  def asMarkdown: String = {
+    val headers   = Seq("Parent", "Name", "Description")
+    val rowWidths = headers.indices.map(i => Math.max(headers(i).length, entries.map(_.asSeq(i).length).max))
 
+    def pad(s: String, chars: Int)  = s + " " * (chars - s.length())
+    def makeLine(line: Seq[String]) = line.indices.map(i => pad(line(i), rowWidths(i))).mkString("| ", " | ", " |")
+
+    val headLine          = makeLine(headers)
+    val headSeparatorLine = headers.indices.map(i => s"-${"-" * rowWidths(i)}-").mkString("|", "|", "|")
+    val entryLines        = entries.map(e => makeLine(e.asSeq))
+
+    (Seq(headLine, headSeparatorLine) ++ entryLines).mkString("\n")
+  }
+
+  def asHtml: String = {
+    val headers = Seq("Parent", "Name", "Description")
+    val thead   =
+      s"""<thead>
+         |<tr>
+         |${headers.map(h => s"    <th>$h</th>").mkString("\n")}
+         |  </tr>
+         |</thead>""".stripMargin
+
+    val tbodyRows =
+      entries
+        .map { e =>
+          val tds = e.asSeq.map(x => s"    <td>$x</td>").mkString("\n")
+          s"""  <tr>
+             |$tds
+             |  </tr>""".stripMargin
+        }
+        .mkString("\n")
+
+    s"""<table>
+       |$thead
+       |<tbody>
+       |$tbodyRows
+       |</tbody>
+       |</table>""".stripMargin
+  }
 }
 
 object Glossary {
-
-  case class Entry(name: String, description: Option[String], children: List[Entry])
-
-  def build(docs: Documentation): Glossary = {
-    ???
+  case class Entry(parent: Option[Entry], name: String, description: Option[String]) {
+    def asSeq: Seq[String] = Seq(parent.map(_.name).getOrElse(""), name, description.getOrElse(""))
   }
 
+  def build(docs: Documentation): Glossary = {
 
+    val cache = scala.collection.mutable.Map.empty[(String, Option[String]), Glossary.Entry]
+
+    val documentedSymbols = docs.symbols.map(s => s.symbol -> s).toMap
+
+    def upsert(name: String, desc: Option[String], parent: Option[Glossary.Entry]): Glossary.Entry =
+      cache
+        .getOrElseUpdate(
+          (name, parent.map(_.name)),
+          Entry(parent, name, desc),
+        )
+
+    docs.symbols.map { s =>
+      val parentOpt =
+        s.path.foldLeft(Option.empty[Glossary.Entry]) { (maybeParent, symbol) =>
+          documentedSymbols.get(symbol) match {
+            case Some(docParent) =>
+              Some(
+                upsert(
+                  name = docParent.nameOverride.getOrElse(docParent.symbol.name.toString),
+                  desc = docParent.description,
+                  parent = maybeParent,
+                ),
+              )
+            case None            =>
+              maybeParent
+          }
+        }
+      val leafName  = s.nameOverride.getOrElse(s.symbol.name.toString)
+      upsert(leafName, s.description, parentOpt)
+    }
+
+    Glossary(cache.values.toList)
+  }
+
+  def write(docs: String, path: String): Unit = {
+    Files.write(Path.of(path), docs.getBytes)
+  }
 }

--- a/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/application/Application.scala
+++ b/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/application/Application.scala
@@ -1,0 +1,51 @@
+package domaindocs4s.banking.application
+
+import domaindocs4s.banking.common.*
+import domaindocs4s.banking.party.*
+import domaindocs4s.*
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+@domainDoc("Loan application submitted by the customer for processing.")
+final case class Application(
+    id: Application.Id,
+    applicant: Party,
+    income: List[Income],
+    liability: List[Liability],
+    terms: Application.LoanTerms,
+    status: ApplicationStatus,
+    submittedAt: LocalDateTime,
+) {
+
+  @domainDoc("Marks the loan application as submitted by the customer.")
+  def submit(): Unit = ()
+
+  @domainDoc("Approves the loan application after successful review.")
+  def approve(): Unit = ()
+
+  @domainDoc("Rejects the loan application, preventing further processing.")
+  def reject(): Unit = ()
+
+  @domainDoc("Disburses the approved loan amount to the customer.")
+  def disburse(): Unit = ()
+
+}
+
+object Application {
+
+  @domainDoc("Unique technical identifier of a loan application.", "ApplicationId")
+  final case class Id(value: UUID)
+
+  @domainDoc("Requested loan terms, including amount, duration, and purpose.")
+  final case class LoanTerms(amount: Money, durationInMonths: Int, purpose: String)
+
+}
+
+@domainDoc("Current status of the loan application.")
+enum ApplicationStatus {
+  case Submitted
+  case Approved
+  case Rejected(reason: String)
+  case Disbursed
+}

--- a/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/application/Income.scala
+++ b/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/application/Income.scala
@@ -1,0 +1,20 @@
+package domaindocs4s.banking.application
+
+import domaindocs4s.banking.common.*
+import domaindocs4s.domainDoc
+
+@domainDoc("Customer's declared income, including monthly amount and source.")
+final case class Income(
+    monthlyAmount: Money,
+    source: IncomeSource,
+)
+
+@domainDoc("Type of the customer's primary income source.")
+enum IncomeSource {
+  case Employment
+  case SelfEmployment
+  case Rental
+  case Investment
+  case Pension
+  case Other
+}

--- a/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/application/Liability.scala
+++ b/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/application/Liability.scala
@@ -1,0 +1,19 @@
+package domaindocs4s.banking.application
+
+import domaindocs4s.banking.common.*
+import domaindocs4s.domainDoc
+
+@domainDoc("Customer's declared liability, including amount, duration, and type.")
+final case class Liability(
+    amount: Money,
+    durationInMonths: Int,
+    liabilityType: LiabilityType,
+)
+
+@domainDoc("Category of the customer's liability.")
+enum LiabilityType {
+  case Loan
+  case Mortgage
+  case CreditCard
+  case Leasing
+}

--- a/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/common/Money.scala
+++ b/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/common/Money.scala
@@ -1,0 +1,16 @@
+package domaindocs4s.banking.common
+
+import domaindocs4s.domainDoc
+
+@domainDoc("Money value with amount and currency. Defaults to PLN if not specified.")
+final case class Money(
+    amount: BigDecimal,
+    currency: Currency = Currency.PLN,
+)
+
+@domainDoc("Currency supported in the loan application process.")
+enum Currency {
+  case PLN
+  case USD
+  case EUR
+}

--- a/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/party/Address.scala
+++ b/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/party/Address.scala
@@ -1,0 +1,34 @@
+package domaindocs4s.banking.party
+
+import domaindocs4s.domainDoc
+
+@domainDoc("Address details declared by the customer.")
+final case class Address(
+    country: Address.Country,
+    city: Address.City,
+    postalCode: Address.PostalCode,
+    street: Address.Street,
+    houseNumber: Address.HouseNumber,
+    suiteNumber: Option[Address.SuiteNumber],
+)
+
+object Address {
+
+  @domainDoc("Country of the customer's address.")
+  final case class Country(value: String)
+
+  @domainDoc("City of the customer's address.")
+  final case class City(value: String)
+
+  @domainDoc("Postal code of the customer's address.")
+  final case class PostalCode(value: String)
+
+  @domainDoc("Street name of the customer's address.")
+  final case class Street(value: String)
+
+  @domainDoc("House number of the customer's address.")
+  final case class HouseNumber(value: String)
+
+  @domainDoc("Suite, apartment, or flat number of the customer's address.")
+  final case class SuiteNumber(value: String)
+}

--- a/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/party/IdentityDoc.scala
+++ b/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/party/IdentityDoc.scala
@@ -1,0 +1,19 @@
+package domaindocs4s.banking.party
+
+import domaindocs4s.domainDoc
+
+import java.time.LocalDate
+
+@domainDoc("Details from the customer's identity document, including number, type, and expiration date.", "IdentityDocument")
+final case class IdentityDoc(
+    number: String,
+    identityDocType: IdentityDocType,
+    expirationDate: LocalDate,
+)
+
+@domainDoc("Category of the customer's identity document.", "IdentityDocumentType")
+enum IdentityDocType {
+  case ID
+  case Passport
+  case ResidenceCard
+}

--- a/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/party/Party.scala
+++ b/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/party/Party.scala
@@ -21,7 +21,7 @@ final case class Party(
 
 object Party {
 
-  @domainDoc("Unique technical identifier of a party.")
+  @domainDoc("Unique technical identifier of a party.", "PartyId")
   final case class Id(value: UUID)
 
   @domainDoc("First name of the party.")

--- a/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/party/Party.scala
+++ b/domainDocs4s-examples/src/main/scala/domaindocs4s/banking/party/Party.scala
@@ -1,0 +1,36 @@
+package domaindocs4s.banking.party
+
+import domaindocs4s.domainDoc
+
+import java.util.UUID
+
+@domainDoc("Represents a party involved in the loan process, such as a customer, employee, or supplier")
+final case class Party(
+    id: Party.Id,
+    firstName: Party.FirstName,
+    lastName: Party.LastName,
+    personalNumber: Party.PersonalNumber,
+    identityDocType: IdentityDoc,
+    address: Address,
+) {
+
+  @domainDoc("Updates the party's address.")
+  def updateAddress(): Unit = ()
+
+}
+
+object Party {
+
+  @domainDoc("Unique technical identifier of a party.")
+  final case class Id(value: UUID)
+
+  @domainDoc("First name of the party.")
+  final case class FirstName(value: String)
+
+  @domainDoc("Last name of the party.")
+  final case class LastName(value: String)
+
+  @domainDoc("National personal identification number of the party.")
+  final case class PersonalNumber(value: String)
+
+}


### PR DESCRIPTION
This PR adds:
- an `examples` module
- a simple `banking` domain model for future tests
- basic glossary output generation

To do:
- [ ] improve ordering in the output glossary
- [ ] test the feature on a more nested model