### PR TITLE
Add ensureLiteral macro

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,4 +41,4 @@ lazy val examples = (project in file("domainDocs4s-examples"))
     semanticdbEnabled := true,
   )
   .dependsOn(api)
-  .dependsOn(tastyQueryCollector)
+  .dependsOn(tastyQueryCollector % "test->test")

--- a/domainDocs4s-collector/src/main/scala/domaindocs4s/collector/Collector.scala
+++ b/domainDocs4s-collector/src/main/scala/domaindocs4s/collector/Collector.scala
@@ -4,7 +4,7 @@ import domaindocs4s.errors.DomainDocsArgError
 import tastyquery.{Contexts, Symbols}
 import tastyquery.Contexts.Context
 import tastyquery.Symbols.{DeclaringSymbol, Symbol, TermSymbol}
-import tastyquery.Trees.{Literal, Select}
+import tastyquery.Trees._
 
 import scala.collection.mutable.ListBuffer
 
@@ -58,6 +58,14 @@ class TastyQueryCollector(using ctx: Context) extends Collector {
   private def asDocumented(symbol: Symbol, path: Vector[DeclaringSymbol]): Option[DocumentedSymbol] = {
     println(s"$symbol - ${symbol.displayFullName}")
 
+    def unwrap(tree: Tree): Tree = tree match {
+      case Inlined(t, _, _) => unwrap(t)
+      case Typed(t, _) => unwrap(t)
+      case Block(Nil, t) => unwrap(t)
+      case TypeApply(f, _) => unwrap(f)
+      case _ => tree
+    }
+
     symbol match {
       case ts: TermSymbol if ts.isModuleVal =>
         None
@@ -66,7 +74,7 @@ class TastyQueryCollector(using ctx: Context) extends Collector {
           .getAnnotation(domainDocAnnotation)
           .map(annot => {
             def getConstArg(index: Int, label: String): Option[String] = {
-              annot.arguments(index) match {
+              unwrap(annot.arguments(index)) match {
                 case Literal(constant) => Some(constant.stringValue)
                 case Select(_, termName) if termName.toString == s"<init>$$default$$${index + 1}" => None
                 case _ => throw DomainDocsArgError(label, symbol.displayFullName)

--- a/domainDocs4s-collector/src/main/scala/domaindocs4s/macros/Literals.scala
+++ b/domainDocs4s-collector/src/main/scala/domaindocs4s/macros/Literals.scala
@@ -1,0 +1,35 @@
+package domaindocs4s.macros
+
+import scala.quoted.{Expr, Quotes, Type}
+
+object Literals {
+  
+  transparent inline def ensureLiteral[T](inline value: T): T = {
+    ${ ensureLiteralImpl('value) }
+  }
+
+  private def ensureLiteralImpl[T: Type](value: Expr[T])(using quotes: Quotes): Expr[T] = {
+    import quotes.reflect._
+
+    def unwrap(t: Term): Term = t match {
+      case Inlined(_, _, t) => unwrap(t)
+      case Typed(t, _) => unwrap(t)
+      case Block(Nil, t) => unwrap(t)
+      case _ => t
+    }
+
+    val term = unwrap(value.asTerm)
+
+    term match
+      case Literal(_) =>
+        value
+      case _ =>
+        report.errorAndAbort(
+          s"""Expected a literal (Literal(Constant(...))).
+             |Got (pretty): ${term.show}
+             |Got (structure): ${term.show(using Printer.TreeStructure)}
+             |""".stripMargin
+        )
+  }
+
+}

--- a/domainDocs4s-collector/src/main/scala/domaindocs4s/macros/package.scala
+++ b/domainDocs4s-collector/src/main/scala/domaindocs4s/macros/package.scala
@@ -1,0 +1,8 @@
+package domaindocs4s
+
+package object macros:
+  object literals:
+    export domaindocs4s.macros.Literals._
+    
+  object all:
+    export literals._

--- a/domainDocs4s-collector/src/test/scala/domaindocs4s/macros/LiteralsSpec.scala
+++ b/domainDocs4s-collector/src/test/scala/domaindocs4s/macros/LiteralsSpec.scala
@@ -1,0 +1,59 @@
+package domaindocs4s.macros
+
+import org.scalatest.freespec.AnyFreeSpec
+import scala.compiletime.testing.*
+
+class LiteralsSpec extends AnyFreeSpec {
+
+  "ensureLiteral" - {
+
+    "compiles for literal / reducible-to-literal expressions" - {
+
+      val literal =
+        typeChecks("""import domaindocs4s.macros.literals.*
+                     |ensureLiteral("literal")
+                     |""".stripMargin)
+
+      assert(literal)
+
+      val concat =
+        typeChecks("""import domaindocs4s.macros.literals.*
+                     |ensureLiteral("lit" + "eral")
+                     |""".stripMargin)
+
+      assert(concat)
+
+      val inlineDef =
+        typeChecks("""import domaindocs4s.macros.literals.*
+                     |transparent inline def literal = ensureLiteral("literal")
+                     |literal
+                     |""".stripMargin)
+
+      assert(inlineDef)
+    }
+
+    "fails when expression can't be reduced to literal" - {
+
+      val valRef = typeCheckErrors(
+        """import domaindocs4s.macros.literals.*
+          |val x = "literal"
+          |ensureLiteral(x)
+          |""".stripMargin,
+      )
+
+      assert(valRef.nonEmpty)
+      assert(valRef.map(_.message).mkString("\n").contains("Expected a literal"))
+
+      val interpolation = typeCheckErrors(
+        """import domaindocs4s.macros.literals.*
+          |ensureLiteral(s"literal")
+          |""".stripMargin,
+      )
+
+      assert(interpolation.nonEmpty)
+      assert(interpolation.map(_.message).mkString("\n").contains("Expected a literal"))
+
+    }
+
+  }
+}


### PR DESCRIPTION
Related to #4 
I started by exploring dynamic content using `inlines`, as this seemed like the simplest entry point. The initial goal was limited to string reuse.

The first experiments show that `val` and `def` declarations are always represented as `Ident(...)` in `.tasty` files, even when marked as `inline`.
To make them appear as compile-time literals, we need to use `transparent inline def`.

However, this approach only allows standard string operations. Any operation that cannot be reduced to a literal at compile time (even simple string interpolation) is inlined into a fairly complex `TermTree`, which would be difficult to interpret or evaluate reliably.

With this in mind, we could introduce simple macros to support more advanced string operations.
Since the final expression must still reduce to a literal, passing an arbitrary operation as a macro argument seems difficult. However, modeling supported operations as a small ADT and interpreting them inside the macro appears to be a feasible approach.

Regarding type-level computations, it seems that we still need to rely on `constValue[T]` to obtain the value of a singleton type `T`. Under the hood, this is also implemented as a `transparent inline def`.
This area still requires further exploration.


This is only the first step in exploring dynamic content. I will continue working on this, so there is no action needed on this PR at the moment. However, any comments or suggestions are very welcome.